### PR TITLE
Api upgrade

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var rtcSupport = require('webrtcsupport')
 
 var emitfn = Emitter.prototype.emit
 
-function Socketiop2p (opts, socket) {
+function Socketiop2p (socket, opts) {
   var self = this
   self.useSockets = true
   self.usePeerConnection = false
@@ -25,6 +25,7 @@ function Socketiop2p (opts, socket) {
   self.numConnectedClients
   self.readyPeers = 0
   self.ready = false
+  self.trickle = opts.trickle !== undefined ? opts.trickle : true
   self._peerEvents = {
                    upgrade: 1,
                    error: 1,
@@ -52,7 +53,7 @@ function Socketiop2p (opts, socket) {
       }
       function generateOffer () {
         var offerId = hat(160)
-        var peerOpts = extend(opts, {initiator: true, trickle: true})
+        var peerOpts = extend(opts, {initiator: true, trickle: self.trickle})
         var peer = self._peers[offerId] = new Peer(peerOpts)
         peer.setMaxListeners(50)
         self.setupPeerEvents(peer)
@@ -80,7 +81,7 @@ function Socketiop2p (opts, socket) {
   })
 
   socket.on('offer', function (data) {
-    var peerOpts = extend(opts, {initiator: false, trickle: true})
+    var peerOpts = extend(opts, {initiator: false, trickle: self.trickle})
     var peer = self._peers[data.fromPeerId] = new Peer(peerOpts)
     self.numConnectedClients++
     peer.setMaxListeners(50)

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function Socketiop2p (opts, socket) {
   self.readyPeers = 0
   self.ready = false
   self._peerEvents = {
-                   ready: 1,
+                   upgrade: 1,
                    error: 1,
                    peer_signal: 1,
                    peer_ready: 1
@@ -124,7 +124,7 @@ function Socketiop2p (opts, socket) {
     if (self.readyPeers >= self.numConnectedClients && !self.ready) {
       self.ready = true
       if (!opts.autoUpgrade) self.usePeerConnection = true
-      self.emit('ready')
+      self.emit('upgrade')
     }
   })
 

--- a/index.js
+++ b/index.js
@@ -12,13 +12,14 @@ var rtcSupport = require('webrtcsupport')
 
 var emitfn = Emitter.prototype.emit
 
-function Socketiop2p (socket, opts) {
+function Socketiop2p (socket, opts, cb) {
   var self = this
   self.useSockets = true
   self.usePeerConnection = false
   self.decoder = new parser.Decoder(this)
   self.decoder.on('decoded', bind(this, this.ondecoded))
   self.socket = socket
+  self.cb = cb
   self.opts = opts
   self._peers = {}
   self.numClients = opts.numClients || 5
@@ -125,6 +126,7 @@ function Socketiop2p (socket, opts) {
     if (self.readyPeers >= self.numConnectedClients && !self.ready) {
       self.ready = true
       if (!opts.autoUpgrade) self.usePeerConnection = true
+      if (typeof self.cb === 'function') self.cb()
       self.emit('upgrade')
     }
   })

--- a/test/specs/connection.js
+++ b/test/specs/connection.js
@@ -4,30 +4,22 @@ var io = require('socket.io-client')
 var manager1 = io.Manager()
 var manager2 = io.Manager()
 var manager3 = io.Manager()
-var peerOpts = {}
+var peerOpts = {trickle: false}
 
 test('it should support multi-way communication', function (t) {
   t.plan(2)
   var namespace = '/multi'
-  var socket1, socket2, socket3, p2p1, p2p2, p2p3
+  var socket1 = manager1.socket(namespace)
+  var p2p1 = new Socketiop2p(socket1, peerOpts)
 
-  setTimeout(function () {
-    socket1 = manager1.socket(namespace)
-    p2p1 = new Socketiop2p(peerOpts, socket1)
-  }, 25)
+  var socket2 = manager2.socket(namespace)
+  var p2p2 = new Socketiop2p(socket2, peerOpts)
 
-  setTimeout(function () {
-    socket2 = manager2.socket(namespace)
-    p2p2 = new Socketiop2p(peerOpts, socket2)
-  }, 50)
-
-  setTimeout(function () {
-    socket3 = manager3.socket(namespace)
-    p2p3 = new Socketiop2p(peerOpts, socket3)
-    p2p3.on('upgrade', function () {
-      runTest()
-    })
-  }, 75)
+  var socket3 = manager3.socket(namespace)
+  var p2p3 = new Socketiop2p(socket3, peerOpts)
+  p2p3.on('upgrade', function () {
+    runTest()
+  })
 
   var readyPeers = {}
   var jsonObj = {ping: 'pong', ding: {dong: 'song'}}
@@ -48,20 +40,14 @@ test('it should support multi-way communication', function (t) {
 test('Socket inter-operability', function (t) {
   t.plan(2)
   var namespace = '/inter'
-  var socket1, socket2, p2p1, p2p2
+  var socket1 = manager1.socket(namespace)
+  var p2p1 = new Socketiop2p(socket1, peerOpts)
 
-  setTimeout(function () {
-    socket1 = manager1.socket(namespace)
-    p2p1 = new Socketiop2p(peerOpts, socket1)
-  }, 25)
-
-  setTimeout(function () {
-    socket2 = manager2.socket(namespace)
-    p2p2 = new Socketiop2p(peerOpts, socket2)
-    p2p2.on('upgrade', function () {
-      runTest()
-    })
-  }, 50)
+  var socket2 = manager2.socket(namespace)
+  var p2p2 = new Socketiop2p(socket2, peerOpts)
+  p2p2.on('upgrade', function () {
+    runTest()
+  })
 
   function runTest () {
     var jsonObj = {ping: 'pong', ding: {dong: 'song'}}
@@ -82,5 +68,4 @@ test('Socket inter-operability', function (t) {
     })
     p2p1.emit('socket-obj', jsonObj)
   }
-
 })

--- a/test/specs/connection.js
+++ b/test/specs/connection.js
@@ -16,10 +16,7 @@ test('it should support multi-way communication', function (t) {
   var p2p2 = new Socketiop2p(socket2, peerOpts)
 
   var socket3 = manager3.socket(namespace)
-  var p2p3 = new Socketiop2p(socket3, peerOpts)
-  p2p3.on('upgrade', function () {
-    runTest()
-  })
+  var p2p3 = new Socketiop2p(socket3, peerOpts, runTest)
 
   var readyPeers = {}
   var jsonObj = {ping: 'pong', ding: {dong: 'song'}}
@@ -44,10 +41,7 @@ test('Socket inter-operability', function (t) {
   var p2p1 = new Socketiop2p(socket1, peerOpts)
 
   var socket2 = manager2.socket(namespace)
-  var p2p2 = new Socketiop2p(socket2, peerOpts)
-  p2p2.on('upgrade', function () {
-    runTest()
-  })
+  var p2p2 = new Socketiop2p(socket2, peerOpts, runTest)
 
   function runTest () {
     var jsonObj = {ping: 'pong', ding: {dong: 'song'}}
@@ -68,4 +62,16 @@ test('Socket inter-operability', function (t) {
     })
     p2p1.emit('socket-obj', jsonObj)
   }
+})
+
+test('Optional callback is called on upgrade', function (t) {
+  t.plan(1)
+  var namespace = '/cb'
+  var socket1 = manager1.socket(namespace)
+  var p2p1 = new Socketiop2p(socket1, peerOpts)
+
+  var socket2 = manager2.socket(namespace)
+  var p2p2 = new Socketiop2p(socket2, peerOpts, function () {
+    t.pass('Callback was called')
+  })
 })

--- a/test/specs/connection.js
+++ b/test/specs/connection.js
@@ -24,7 +24,7 @@ test('it should support multi-way communication', function (t) {
   setTimeout(function () {
     socket3 = manager3.socket(namespace)
     p2p3 = new Socketiop2p(peerOpts, socket3)
-    p2p3.on('ready', function () {
+    p2p3.on('upgrade', function () {
       runTest()
     })
   }, 75)
@@ -58,7 +58,7 @@ test('Socket inter-operability', function (t) {
   setTimeout(function () {
     socket2 = manager2.socket(namespace)
     p2p2 = new Socketiop2p(peerOpts, socket2)
-    p2p2.on('ready', function () {
+    p2p2.on('upgrade', function () {
       runTest()
     })
   }, 50)

--- a/test/specs/messaging.js
+++ b/test/specs/messaging.js
@@ -12,10 +12,7 @@ test('it should receive utf8 multibyte characters', function (t) {
   var p2p1 = new P2P(socket1, peerOpts)
 
   var socket2 = manager2.socket(namespace)
-  var p2p2 = new P2P(socket2, peerOpts)
-  p2p2.on('upgrade', function () {
-    runTest()
-  })
+  var p2p2 = new P2P(socket2, peerOpts, runTest)
 
   function runTest () {
     p2p1.usePeerConnection = true
@@ -64,10 +61,7 @@ test('it should send and receive binary data', function (t) {
   var p2p1 = new P2P(socket1, peerOpts)
 
   var socket2 = manager2.socket(namespace)
-  var p2p2 = new P2P(socket2, peerOpts)
-  p2p2.on('upgrade', function () {
-    runTest()
-  })
+  var p2p2 = new P2P(socket2, peerOpts, runTest)
 
   var binaryPacket = {data: new Uint8Array(16)}
 

--- a/test/specs/messaging.js
+++ b/test/specs/messaging.js
@@ -3,25 +3,19 @@ var P2P = require('../../index')
 var io = require('socket.io-client')
 var manager1 = io.Manager()
 var manager2 = io.Manager()
-var peerOpts = {}
+var peerOpts = {trickle: false}
 
 test('it should receive utf8 multibyte characters', function (t) {
   t.plan(3)
   var namespace = '/array'
-  var socket1, socket2, p2p1, p2p2
+  var socket1 = manager1.socket(namespace)
+  var p2p1 = new P2P(socket1, peerOpts)
 
-  setTimeout(function () {
-    socket1 = manager1.socket(namespace)
-    p2p1 = new P2P(peerOpts, socket1)
-  }, 25)
-
-  setTimeout(function () {
-    socket2 = manager2.socket(namespace)
-    p2p2 = new P2P(peerOpts, socket2)
-    p2p2.on('upgrade', function () {
-      runTest()
-    })
-  }, 50)
+  var socket2 = manager2.socket(namespace)
+  var p2p2 = new P2P(socket2, peerOpts)
+  p2p2.on('upgrade', function () {
+    runTest()
+  })
 
   function runTest () {
     p2p1.usePeerConnection = true
@@ -66,20 +60,14 @@ test('it should receive utf8 multibyte characters', function (t) {
 test('it should send and receive binary data', function (t) {
   t.plan(1)
   var namespace = '/blob'
-  var socket1, socket2, p2p1, p2p2
+  var socket1 = manager1.socket(namespace)
+  var p2p1 = new P2P(socket1, peerOpts)
 
-  setTimeout(function () {
-    socket1 = manager1.socket(namespace)
-    p2p1 = new P2P(peerOpts, socket1)
-  }, 25)
-
-  setTimeout(function () {
-    socket2 = manager2.socket(namespace)
-    p2p2 = new P2P(peerOpts, socket2)
-    p2p2.on('upgrade', function () {
-      runTest()
-    })
-  }, 50)
+  var socket2 = manager2.socket(namespace)
+  var p2p2 = new P2P(socket2, peerOpts)
+  p2p2.on('upgrade', function () {
+    runTest()
+  })
 
   var binaryPacket = {data: new Uint8Array(16)}
 

--- a/test/specs/messaging.js
+++ b/test/specs/messaging.js
@@ -18,7 +18,7 @@ test('it should receive utf8 multibyte characters', function (t) {
   setTimeout(function () {
     socket2 = manager2.socket(namespace)
     p2p2 = new P2P(peerOpts, socket2)
-    p2p2.on('ready', function () {
+    p2p2.on('upgrade', function () {
       runTest()
     })
   }, 50)
@@ -76,7 +76,7 @@ test('it should send and receive binary data', function (t) {
   setTimeout(function () {
     socket2 = manager2.socket(namespace)
     p2p2 = new P2P(peerOpts, socket2)
-    p2p2.on('ready', function () {
+    p2p2.on('upgrade', function () {
       runTest()
     })
   }, 50)

--- a/test/support/server.js
+++ b/test/support/server.js
@@ -19,3 +19,6 @@ server.of('/multi')
 
 server.of('/blob')
 .use(p2pserver)
+
+server.of('/cb')
+.use(p2pserver)


### PR DESCRIPTION
Changes the `ready` to `upgrade` (breaking change)
Moves the socket object to first arguement in constructor
Allows optional callback
Allows trickle setting to be overwridden - fixes https://github.com/socketio/socket.io-p2p/issues/1