### PR TITLE
updates require to match package.json naming

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 window.myDebug = require('debug')
 var Peer = require('simple-peer')
 var Emitter = require('component-emitter')
-var parser = require('socket.io-parser')
+var parser = require('socket.io-p2p-parser')
 var toArray = require('to-array')
 var hasBin = require('has-binary')
 var bind = require('component-bind')


### PR DESCRIPTION
I was receiving an error webpacking this module. 
It appears that the parser was named differently between the package.json and the index file.  However I wasn't running into this issue until fairly recently and have been using this for a while so maybe I overlooked something somewhere else?