### PR TITLE
Add media streaming example

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ p2p.on('ready', function(){
   p2p.emit('peer-obj', { peerId: peerId });
 })
 
-// this event will be triggered over the socket transport 
+// this event will be triggered over the socket transport
 // until `usePeerConnection` is set to `true`
 p2p.on('peer-msg', function(data){
   console.log(data);
@@ -66,7 +66,7 @@ The `opts` object can include options for setup of the overall socket.io-p2p con
 
 - `numClients` - max number of peers each client can connect to; `5` by default.
 - `autoUpgrade` - upgrade to a p2p connection (from s.io one) when peers are ready; `true` by default
-- `peerOpts` - object of options to be passed to underlying peers. See [here](https://github.com/feross/simple-peer/blob/master/README.md#api) for currently supported options.
+- `peerOpts` - object of options to be passed to underlying peers. See [here](https://github.com/feross/simple-peer/blob/master/README.md#api) for currently supported options. See [here](examples/streaming) for an example.
 
 `cb` is an optional callback. Called when connection is upgraded to a WebRTC connection.
 

--- a/examples/streaming/README.md
+++ b/examples/streaming/README.md
@@ -1,0 +1,17 @@
+# socket.io-p2p streaming example
+
+## Install dependencies
+If you haven't done so already, go to the root of the repository and `npm install` the dependencies.
+
+## Run
+To start, `cd` to this directory (`examples/streaming`) and run the following:
+
+```
+browserify src/index.js -o bundle.js
+node server.js
+```
+
+(You will need `browserify` for this. If it isn't installed get it with `npm install --global browserfiy`)
+
+## Further examples
+See [feross/simple-peer](https://github.com/feross/simple-peer#videovoice) for additional examples on how to stream media.

--- a/examples/streaming/index.html
+++ b/examples/streaming/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Socket.io-p2p Streaming Example</title>
+</head>
+<body>
+  <h1>Socket.io-p2p Streaming Example</h1>
+  <button id="start-stream">Start streaming</button>
+  <audio controls></audio>
+  <script src="/bundle.js"></script>
+</body>
+</html>

--- a/examples/streaming/server.js
+++ b/examples/streaming/server.js
@@ -1,0 +1,19 @@
+var ecstatic = require('ecstatic')
+var server = require('http').createServer(
+  ecstatic({ root: __dirname, handleError: false })
+)
+var p2pserver = require('socket.io-p2p-server').Server
+var io = require('socket.io')(server)
+
+server.listen(3030, function () {
+  console.log('Listening on 3030')
+})
+
+io.use(p2pserver)
+
+io.on('connection', function (socket) {
+  socket.on('start-stream', function (data) {
+    console.log('Stream started')
+    socket.broadcast.emit('start-stream', data)
+  })
+})

--- a/examples/streaming/src/index.js
+++ b/examples/streaming/src/index.js
@@ -1,0 +1,42 @@
+var P2P = require('../../../index')
+var io = require('socket.io-client')
+
+window.AudioContext = window.AudioContext || window.webkitAudioContext
+
+var socket = io()
+var p2p = new P2P(socket)
+var startButton = document.getElementById('start-stream')
+
+p2p.on('start-stream', function () {
+  p2p.usePeerConnection = true
+  startButton.setAttribute('disabled', true)
+})
+
+p2p.on('stream', function (stream) {
+  var audio = document.querySelector('audio')
+  audio.src = window.URL.createObjectURL(stream)
+  audio.play()
+})
+
+function startStream () {
+  startButton.setAttribute('disabled', true)
+  navigator.getUserMedia({ audio: true }, function (stream) {
+    var audioContext = new window.AudioContext()
+    var mediaStreamSource = audioContext.createMediaStreamSource(stream)
+    var mediaStreamDestination = audioContext.createMediaStreamDestination()
+    mediaStreamSource.connect(mediaStreamDestination)
+
+    var socket = io()
+    var p2p = new P2P(socket, {peerOpts: {stream: mediaStreamDestination.stream}})
+
+    p2p.on('ready', function () {
+      p2p.usePeerConnection = true
+    })
+
+    p2p.emit('ready', { peerId: p2p.peerId })
+  }, function (err) {
+    console.log(err)
+  })
+}
+
+startButton.addEventListener('click', startStream)


### PR DESCRIPTION
Takes microphone input from one device and streams it to the other. Is
an example of how to use peerOpts with simple-peer.

I made this example after having a lot of trouble working out how to do streaming with socket.io-p2p. I thought this could be quite useful for people in a similar situation as I was.