### PR TITLE
fixing type

### DIFF
--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -11,4 +11,4 @@ browserify src/index.js -o bundle.js
 node server.js
 ```
 
-(You will need `browserify` for this. If it isn't installed get it with `npm install --global browserfiy`)
+(You will need `browserify` for this. If it isn't installed get it with `npm install --global browserify`)


### PR DESCRIPTION
npm install -g browserify is working while there was npm install -g browserfiy wich gave me 404 error